### PR TITLE
Enable to set a hash param in very very limited conditions

### DIFF
--- a/app/controllers/samplar/application_controller.rb
+++ b/app/controllers/samplar/application_controller.rb
@@ -22,7 +22,17 @@ module Samplar
     end
 
     def array_params
-      passing_args.map{|arg| create_params[arg.to_sym]}
+      passing_args.map do |arg|
+        if arg == 'options'
+          if key_value = create_params[arg.to_sym].split(':')
+            { key_value[0].to_sym => key_value[1] }
+          else
+            {}
+          end
+        else
+          create_params[arg.to_sym]
+        end
+      end
     end
   end
 end

--- a/lib/samplar/version.rb
+++ b/lib/samplar/version.rb
@@ -1,3 +1,3 @@
 module Samplar
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
```rb
# config/samplar.yml

Sample::Client:
  post:
    - method
    - options
```
![image](https://user-images.githubusercontent.com/17349045/75088660-c1e84680-5593-11ea-8ee1-d1872de1fd11.png)

1. Set the argument name `options` in yml.
1. Set `:` delimiter like `key:value`
1. Translate args to `{ "key" => "value" }` and pass to method.
